### PR TITLE
added code path to handle tarball input data

### DIFF
--- a/current_docker_list.txt
+++ b/current_docker_list.txt
@@ -12,3 +12,4 @@ quay.io/ncigdc/gdc-rnaseq-tool:c52fbf53552b9faea617dca86b0ce289cc3dafc8
 quay.io/ncigdc/picard:b4d47c60366e12f8cc3ffb264e510c1165801eae1d6329d94ef9e6c30e972991
 quay.io/ncigdc/samtools:147bd4cc606a63c7435907d97fea6e94e9ea9ed58c18f390cab8bc40b1992df7
 quay.io/ncigdc/star2:feat_2.7.0f
+quay.io/ncigdc/bio-tarball-to-fastqgz:1.0.0

--- a/tools/extract_fastqs_from_tarball.cwl
+++ b/tools/extract_fastqs_from_tarball.cwl
@@ -3,7 +3,6 @@ class: CommandLineTool
 id: extract_fastqs_from_tarball
 requirements:
   - class: DockerRequirement
-    # dockerPull: quay.io/ncigdc/bio-tarball-to-fastqgz:latest
     dockerPull: quay.io/ncigdc/bio-tarball-to-fastqgz:1.0.0
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
@@ -32,12 +31,6 @@ inputs:
       position: 2
 
 outputs:
-  # fastqgz:
-  #   type:
-  #     type: array
-  #     items: File
-  #   outputBinding:
-  #     glob: "*.fastq.gz"
   readgroup_fastq_file_list:
     type: 
       type: array
@@ -63,8 +56,3 @@ outputs:
           console.log(updated)
           return updated
         }
-
-# baseCommand: 
-#  - /mnt/dev/BINF-369_tcga_rnaseq_tarball/venv/bin/python
-#  - /home/ubuntu/dev/BINF-369_tcga_rnaseq_tarball/bio-tarball-to-fastqgz/tarball_to_fastqgz/main.py
-

--- a/tools/extract_fastqs_from_tarball.cwl
+++ b/tools/extract_fastqs_from_tarball.cwl
@@ -1,0 +1,70 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: extract_fastqs_from_tarball
+requirements:
+  - class: DockerRequirement
+    # dockerPull: quay.io/ncigdc/bio-tarball-to-fastqgz:latest
+    dockerPull: quay.io/ncigdc/bio-tarball-to-fastqgz:1.0.0
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    coresMin: 1
+    coresMax: 1
+    ramMin: 1024
+    ramMax: 1024
+    tmpdirMin: $(Math.ceil(inputs.file_size / 1048576))
+    tmpdirMax: $(Math.ceil(inputs.file_size / 1048576))
+    outdirMin: $(Math.ceil(inputs.file_size / 1048576))
+    outdirMax: $(Math.ceil(inputs.file_size / 1048576))
+  - class: SchemaDefRequirement
+    types:
+      - $import: readgroup.cwl
+
+inputs:
+  tarball:
+    type: File
+    inputBinding:
+      prefix: --tarball
+      position: 1
+  sample_uuid:
+    type: string
+    inputBinding:
+      prefix: --sample
+      position: 2
+
+outputs:
+  # fastqgz:
+  #   type:
+  #     type: array
+  #     items: File
+  #   outputBinding:
+  #     glob: "*.fastq.gz"
+  readgroup_fastq_file_list:
+    type: 
+      type: array
+      items: readgroup.cwl#readgroup_fastq_file
+    outputBinding:
+      glob: "*.json"
+      loadContents: true
+      outputEval: |
+        ${
+          console.log("matched json object")
+          console.log(self[0])
+          var res = JSON.parse(self[0].contents)
+          var location = self[0].location.replace(self[0].basename, '')
+          location = location.replace('file://', '')
+          var re = /^\//i
+          var expand_path = function(item){
+            item.forward_fastq.location = location + item.forward_fastq.location.replace(re, '')
+            item.reverse_fastq.location = location + item.reverse_fastq.location.replace(re, '')
+            return item
+          }
+          var updated = res.map(expand_path)
+          console.log("UPDATED:")
+          console.log(updated)
+          return updated
+        }
+
+# baseCommand: 
+#  - /mnt/dev/BINF-369_tcga_rnaseq_tarball/venv/bin/python
+#  - /home/ubuntu/dev/BINF-369_tcga_rnaseq_tarball/bio-tarball-to-fastqgz/tarball_to_fastqgz/main.py
+

--- a/tools/picard_collectrnaseqmetrics.cwl
+++ b/tools/picard_collectrnaseqmetrics.cwl
@@ -111,9 +111,6 @@ outputs:
     outputBinding:
       glob: $(inputs.INPUT.nameroot).pdf
 
-arguments:
-
-
 baseCommand: [java]
 
 arguments:

--- a/tools/readgroup.cwl
+++ b/tools/readgroup.cwl
@@ -45,7 +45,7 @@
         type:
           type: array
           items: readgroup_meta
- 
+
   - name: readgroup_fastq_uuid
     type: record
     fields:
@@ -71,3 +71,13 @@
         type:
           type: array
           items: readgroup_meta
+
+  - name: sample_tarball_uuid
+    type: record
+    fields:
+      - name: tarball_uuid
+        type: string
+      - name: tarball_file_size
+        type: long
+      - name: sample_uuid
+        type: string

--- a/workflows/star2pass.rnaseq_harmonization.cwl
+++ b/workflows/star2pass.rnaseq_harmonization.cwl
@@ -23,6 +23,10 @@ inputs:
     type:
       type: array
       items: ../tools/readgroup.cwl#readgroup_bam_uuid
+  sample_tarball_uuid_list:
+    type:
+      type: array
+      items: ../tools/readgroup.cwl#sample_tarball_uuid
   picard_java_mem:
     type: int
     default: 4
@@ -75,6 +79,7 @@ steps:
       bioclient_config: bioclient_config
       readgroup_fastq_uuid_list: readgroup_fastq_uuid_list
       readgroup_bam_uuid_list: readgroup_bam_uuid_list
+      sample_tarball_uuid_list: sample_tarball_uuid_list
       ribosome_intervals_uuid: ribosome_intervals_uuid
       ref_flat_uuid: ref_flat_uuid
       star_index_archive_uuid: star_index_archive_uuid

--- a/workflows/subworkflows/extract/extract_readgroup_tarball_workflow.cwl
+++ b/workflows/subworkflows/extract/extract_readgroup_tarball_workflow.cwl
@@ -1,0 +1,45 @@
+cwlVersion: v1.0
+class: Workflow
+id: gdc_rnaseq_extract_readgroup_tarball_wf
+requirements:
+  - class: SchemaDefRequirement
+    types:
+      - $import: ../../../tools/readgroup.cwl
+  - class: MultipleInputFeatureRequirement
+  - class: StepInputExpressionRequirement
+
+inputs:
+  sample_tarball_uuid:
+    type: ../../../tools/readgroup.cwl#sample_tarball_uuid
+  bioclient_config: File
+
+outputs:
+  output:
+    type:
+      type: array
+      items:  ../../../tools/readgroup.cwl#readgroup_fastq_file
+    outputSource: extract_tarball_readgroup_fastqs/readgroup_fastq_file_list
+
+steps:
+  download_tarball:
+    run: ../../../tools/bioclient_download.cwl
+    in:
+      config-file: bioclient_config
+      download_handle:
+        source: sample_tarball_uuid
+        valueFrom: $(self.tarball_uuid)
+      file_size:
+        source: sample_tarball_uuid
+        valueFrom: $(self.tarball_file_size)
+    out:
+      [ output ]
+
+  extract_tarball_readgroup_fastqs:
+    run: ../../../tools/extract_fastqs_from_tarball.cwl
+    in:
+      tarball: download_tarball/output
+      sample_uuid:
+        source: sample_tarball_uuid
+        valueFrom: $(self.sample_uuid)
+    out:
+      - readgroup_fastq_file_list

--- a/workflows/subworkflows/extract/stage_data_workflow.cwl
+++ b/workflows/subworkflows/extract/stage_data_workflow.cwl
@@ -55,7 +55,6 @@ outputs:
       items: ../../../tools/readgroup.cwl#readgroup_bam_file
     outputSource: extract_bams/output
 
-
 steps:
   extract_ribosome:
     run: ../../../tools/bioclient_download.cwl
@@ -100,10 +99,6 @@ steps:
     in:
       input: extract_tarballs/output
     out: [ output ]
-
-  # merge_fastq_file_outputs
-
-
 
   extract_star_index:
     run: ../../../tools/bioclient_download.cwl


### PR DESCRIPTION
tarball feature uses new python tool to extract files from tarball and results in list of readgroup_fastq_files records which are then merged into existing output
also minor bugfix: removed leftover line from picard_collectrnaseqmetrics.dwl