### PR TITLE
Use new docker for fqvendorfail

### DIFF
--- a/tools/fastq_vendor_fail_filter.cwl
+++ b/tools/fastq_vendor_fail_filter.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: fastq_vendor_fail_filter
 requirements:
   - class: DockerRequirement
-    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:c52fbf53552b9faea617dca86b0ce289cc3dafc8
+    dockerPull: quay.io/ncigdc/fqvendorfail:1.0.0
   - class: InlineJavascriptRequirement
     expressionLib:
       $import: ./util_lib.cwl
@@ -49,4 +49,4 @@ outputs:
     outputBinding:
       glob: $(inputs.output_prefix + '_R2.fq.gz')
  
-baseCommand: [/opt/fqvendorfail/fqvendorfail]
+baseCommand: []

--- a/tools/star_merge_counts.cwl
+++ b/tools/star_merge_counts.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: star_merge_counts
 requirements:
   - class: DockerRequirement
-    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:c52fbf53552b9faea617dca86b0ce289cc3dafc8
+    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:1.0.0
   - class: InlineJavascriptRequirement
     expressionLib:
       $import: ./util_lib.cwl
@@ -32,4 +32,4 @@ outputs:
     outputBinding:
       glob: $(inputs.outfile)
 
-baseCommand: [gdc-rnaseq-tools, merge_star_gene_counts]
+baseCommand: [merge_star_gene_counts]

--- a/tools/star_merge_junctions.cwl
+++ b/tools/star_merge_junctions.cwl
@@ -3,7 +3,7 @@ class: CommandLineTool
 id: star_merge_junctions
 requirements:
   - class: DockerRequirement
-    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:c52fbf53552b9faea617dca86b0ce289cc3dafc8
+    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:1.0.0
   - class: InlineJavascriptRequirement
     expressionLib:
       $import: ./util_lib.cwl
@@ -32,4 +32,4 @@ outputs:
     outputBinding:
       glob: $(inputs.outfile)
 
-baseCommand: [gdc-rnaseq-tools, merge_star_junctions]
+baseCommand: [merge_star_junctions]

--- a/tools/trimmomatic_validate.cwl
+++ b/tools/trimmomatic_validate.cwl
@@ -6,7 +6,7 @@ requirements:
     types:
       - $import: readgroup.cwl
   - class: DockerRequirement
-    dockerPull: quay.io/ncigdc/gdc-rnaseq-tool:c52fbf53552b9faea617dca86b0ce289cc3dafc8
+    dockerPull: quay.io/ncigdc/trimmomatic:0.38
   - class: InlineJavascriptRequirement
     expressionLib:
       $import: ./util_lib.cwl
@@ -81,7 +81,7 @@ outputs:
            return rec
          }
  
-baseCommand: [java, -Xmx4G, -jar, /opt/Trimmomatic-0.38/trimmomatic-0.38.jar] 
+baseCommand: [-Xmx4G, -jar, /bin/trimmomatic.jar] 
 
 arguments:
   - valueFrom: |


### PR DESCRIPTION
Updates to the CWL in conjunction with updates to the `gdc-rnaseq-tool` and new Dockers for `trimommatic` and `fqvendorfail`.

Use these updates as a base for additional workflow updates.